### PR TITLE
Add GitHub permalinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ Here, `settings` is a table as outlined below.
   },
 }
 ```
+
+# Usage
+You can open a file at a line and column using colons:
+```
+nvim file:l:c
+```
+And you can copy the filename to clipboard with the `Fileline` command.

--- a/lua/fileline/construct.lua
+++ b/lua/fileline/construct.lua
@@ -1,5 +1,9 @@
+local function standard(filename, line, column)
+	return filename .. ":" .. line .. ":" .. column
+end
+
 return function()
 	local filename = vim.fn.expand("%:~:.")
-	local l, c = unpack(vim.api.nvim_win_get_cursor(0))
-	return filename .. ":" .. l .. ":" .. c
+	local line, column = unpack(vim.api.nvim_win_get_cursor(0))
+	return standard(filename, line, column)
 end

--- a/lua/fileline/github_perma.lua
+++ b/lua/fileline/github_perma.lua
@@ -1,0 +1,16 @@
+local Job = require("plenary.job")
+
+local function github(repo_url, commit, filename, line1, line2)
+	local permalink = repo_url .. "/blob/" .. commit .. "/" .. filename .. "#L" .. line1
+	if line1 == line2 then
+		return permalink
+	end
+	return permalink .. "-L" .. line2
+end
+
+return function(line1, line2)
+	local filename = vim.fn.expand("%:~:.")
+	local repo_url = Job:new({ command = "gh", args = { "browse", "--no-browser" } }):sync()[1]
+	local commit = Job:new({ command = "git", args = { "rev-parse", "HEAD" } }):sync()[1]
+	return github(repo_url, commit, filename, line1, line2)
+end

--- a/lua/fileline/init.lua
+++ b/lua/fileline/init.lua
@@ -1,4 +1,5 @@
 local construct = require("fileline.construct")
+local github_perma = require("fileline.github_perma")
 local open_file = require("fileline.open_file")
 
 local M = {}
@@ -13,6 +14,11 @@ function M.setup(args)
 		local fileline = construct()
 		vim.fn.setreg(destination_register, fileline)
 	end, {})
+
+	vim.api.nvim_create_user_command("GHPerma", function(t)
+		local fileline = github_perma(t.line1, t.line2)
+		vim.fn.setreg(destination_register, fileline)
+	end, { range = true })
 
 	local grp = vim.api.nvim_create_augroup("fileilne", {})
 


### PR DESCRIPTION
Selecting a visual range and invoking the command `GHPerma` will generate a github permalink for that range. There is no checking that the buffer matches what is in the commit or that the commit has been pushed to github just yet.